### PR TITLE
Fix login value

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8499,7 +8499,7 @@ async function run() {
       core.getInput('project-number', { required: true }) &&
       Number(core.getInput('project-number'))
     const columnName = core.getInput('column-name')
-    const login = github.context.payload.organization.login
+    const login = github.context.repo.owner
 
     const isProjectBeta = await checkIsProjectBeta(login, projectNumber)
 

--- a/src/action.js
+++ b/src/action.js
@@ -25,7 +25,7 @@ async function run() {
       core.getInput('project-number', { required: true }) &&
       Number(core.getInput('project-number'))
     const columnName = core.getInput('column-name')
-    const login = github.context.payload.organization.login
+    const login = github.context.repo.owner
 
     const isProjectBeta = await checkIsProjectBeta(login, projectNumber)
 


### PR DESCRIPTION
`github.context.payload.organization.login` is only available when the action is run on workflow_dispatch, so replacing this with ` github.context.repo.owner` .

Closes #41 