### PR TITLE
fix: use main branch instead of master

### DIFF
--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -32,7 +32,7 @@ jobs:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.PRIVATE_KEY }}
       - name: Add issues to board
-        uses: nearform/github-action-add-issues-to-project@master
+        uses: nearform/github-action-add-issues-to-project@main
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           organizations: ${{ github.event.inputs.organizations }}


### PR DESCRIPTION
With the move to the new organisation, `master` has been renamed to `main`. This keeps this inline.

Closes #232 